### PR TITLE
1.0.0 Release

### DIFF
--- a/Entity/Character/AssistDetail.cs
+++ b/Entity/Character/AssistDetail.cs
@@ -77,28 +77,28 @@ namespace Milimoe.FunGame.Core.Entity
         /// 获取对 <paramref name="enemy"/> 造成伤害的最后时间
         /// </summary>
         /// <param name="enemy"></param>
-        /// <returns>-1 意味着没有时间</returns>
+        /// <returns><see cref="double.MinValue"/> 意味着没有时间</returns>
         public double GetLastTime(Character enemy)
         {
             if (DamageLastTime.TryGetValue(enemy, out double time))
             {
                 return time;
             }
-            return -1;
+            return double.MinValue;
         }
 
         /// <summary>
         /// 获取对某角色友方非伤害辅助的最后时间
         /// </summary>
         /// <param name="character"></param>
-        /// <returns>-1 意味着没有时间</returns>
+        /// <returns><see cref="double.MinValue"/> 意味着没有时间</returns>
         public double GetNotDamageAssistLastTime(Character character)
         {
             if (NotDamageAssistLastTime.TryGetValue(character, out double time))
             {
                 return time;
             }
-            return -1;
+            return double.MinValue;
         }
     }
 }

--- a/Entity/System/RoundRecord.cs
+++ b/Entity/System/RoundRecord.cs
@@ -14,6 +14,7 @@ namespace Milimoe.FunGame.Core.Entity
         public string SkillCost { get; set; } = "";
         public Item? Item { get; set; } = null;
         public bool HasKill { get; set; } = false;
+        public List<Character> Assists { get; set; } = [];
         public Dictionary<Character, double> Damages { get; set; } = [];
         public Dictionary<Character, bool> IsCritical { get; set; } = [];
         public Dictionary<Character, bool> IsEvaded { get; set; } = [];

--- a/FunGame.Core.csproj
+++ b/FunGame.Core.csproj
@@ -18,30 +18,37 @@
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<DocumentationFile></DocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Copyright>Project Redbud and Contributors</Copyright>
+		<Copyright>©2023-Present Project Redbud and Contributors.</Copyright>
 		<PackageId>$(AssemblyName)</PackageId>
     <Description>FunGame.Core: A C#.NET library for turn-based games.</Description>
     <PackageTags>game;turn-based;server;framework;dotnet;csharp;gamedev</PackageTags>
     <PackageReleaseNotes>
-      - Initial release candidate 1 (1.0.0-rc.1-0428)
-      - Abstract ActionQueue as GamingQueue, and separate the original Mix / Team modes into two queue types: MixGamingQueue and TeamGamingQueue. (1.0.0-rc.1-0502)
-      - In the Effect class, added ParentEffect and ForceHideInStatusBar properties for more precise control of the status bar display. (1.0.0-rc.1-0509)
-      - Added helper methods IsTeammate and GetIsTeammateDictionary to GamingQueue for determining if someone is a teammate, IGamingQueue also. This facilitates the skill effects to determine whether the target is a teammate. (1.0.0-rc.1-0509)
-      - Added more properties (such as Name, RealCD) to the ISkill interface. Both NormalAttack and Skill inherit from ISkill, thus implementing these properties, although some properties are not meaningful for NormalAttack. (1.0.0-rc.1-0509)
-      - Added corresponding text for EffectTypes Lifesteal and GrievousWound. (1.0.0-rc.1-0509)
-      - Added EffectTypes: WeakDispelling and StrongDispelling, representing DurativeWeak and DurativeStrong of DispelType. (1.0.0-rc.1-0509)
-      - Added underlying processing support for continuous dispelling in the TimeLapse method. (1.0.0-rc.1-0509)
-      - Fixed an issue where the effect's shield hook provided incorrect parameters. (1.0.0-rc.1-0509)
-      - Fixed an issue where the result of pre-hooks for evade and critical hit checks always deferred to the result of the last effect. It should be that if any effect prevents the check, it is skipped. (1.0.0-rc.1-0509)
-      - Added comments for some code. (1.0.0-rc.1-0509)
-    </PackageReleaseNotes>
+		We are excited to introduce the official version 1.0.0. Here are the key changes from the last release candidate:
+		- Fixed an issue of incorrect recording of non-damage assists. (1.0.0)
+		- Fixed an issue where applying a control effect to an enemy mistakenly resulted in an assist for the character when that enemy killed a teammate. (1.0.0)
+		- Removed the restriction of contributing 10% damage to get an assist. (1.0.0)
+		- Fixed an issue where the skill always defaults to selecting enemies when there is no suitable target, which could cause the character to mistakenly apply a buff state to the enemy. (1.0.0)
+		- Adjusted the basic reward and assist allocation rules for killing enemies. (1.0.0)
+		- Added monetary compensation based on the level and economic difference between the killer/assister and the victim. (1.0.0)
+		Update history of all release candidate versions:
+		- Initial release candidate 1 (1.0.0-rc.1-0428)
+		- Abstract ActionQueue as GamingQueue, and separate the original Mix / Team modes into two queue types: MixGamingQueue and TeamGamingQueue. (1.0.0-rc.1-0502)
+		- In the Effect class, added ParentEffect and ForceHideInStatusBar properties for more precise control of the status bar display. (1.0.0-rc.1-0509)
+		- Added helper methods IsTeammate and GetIsTeammateDictionary to GamingQueue and its interface IGamingQueue for determining if someone is a teammate. This facilitates the skill effects to determine whether the target is a teammate. (1.0.0-rc.1-0509)
+		- Added more properties (such as Name, RealCD) to the ISkill interface. Both NormalAttack and Skill inherit from ISkill, thus implementing these properties, although some properties are not meaningful for NormalAttack. (1.0.0-rc.1-0509)
+		- Added corresponding text for EffectTypes Lifesteal and GrievousWound. (1.0.0-rc.1-0509)
+		- Added EffectTypes: WeakDispelling and StrongDispelling, representing DurativeWeak and DurativeStrong of DispelType. (1.0.0-rc.1-0509)
+		- Added underlying processing support for continuous dispelling in the TimeLapse method. (1.0.0-rc.1-0509)
+		- Fixed an issue where the effect's shield hook provided incorrect parameters. (1.0.0-rc.1-0509)
+		- Fixed an issue where the result of pre-hooks for evade and critical hit checks always deferred to the result of the last effect. It should be that if any effect prevents the check, it is skipped. (1.0.0-rc.1-0509)
+		- Added comments for some code. (1.0.0-rc.1-0509)
+	</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/project-redbud/FunGame-Core</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/project-redbud</PackageProjectUrl>
 		<PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-    <VersionPrefix>1.0.0-rc.1</VersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' == ''">$([System.DateTime]::Now.ToString("MMdd"))</VersionSuffix>
+    <VersionPrefix>1.0.0</VersionPrefix>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Library/Constant/FunGameInfo.cs
+++ b/Library/Constant/FunGameInfo.cs
@@ -23,7 +23,14 @@
         /// <summary>
         /// 核心库的版本号
         /// </summary>
-        public static string FunGame_Version { get; } = $"{FunGame_Version_Major}.{FunGame_Version_Minor}{FunGame_VersionPatch}";
+        public static string FunGame_Version
+        {
+            get
+            {
+                string patch = FunGame_VersionPatch.StartsWith('.') ? FunGame_VersionPatch : $".{FunGame_VersionPatch}";
+                return $"{FunGame_Version_Major}.{FunGame_Version_Minor}{patch}";
+            }
+        }
 
         public const string FunGame_Core = "FunGame Core";
         public const string FunGame_Core_Api = "FunGame Core Api";
@@ -33,7 +40,7 @@
 
         public const int FunGame_Version_Major = 1;
         public const int FunGame_Version_Minor = 0;
-        public const string FunGame_VersionPatch = ".0-rc.1";
+        public const string FunGame_VersionPatch = "0";
         public const string FunGame_Version_Build = "";
 
         public const string FunGameCoreTitle = @"  _____ _   _ _   _  ____    _    __  __ _____    ____ ___  ____  _____ 


### PR DESCRIPTION
Changes from the last release candidate:
- Fixed an issue of incorrect recording of non-damage assists. (1.0.0)
- Fixed an issue where applying a control effect to an enemy mistakenly resulted in an assist for the character when that enemy killed a teammate. (1.0.0)
- Removed the restriction of contributing 10% damage to get an assist. (1.0.0)
- Fixed an issue where the skill always defaults to selecting enemies when there is no suitable target, which could cause the character to mistakenly apply a buff state to the enemy. (1.0.0)
- Adjusted the basic reward and assist allocation rules for killing enemies. (1.0.0)
- Added monetary compensation based on the level and economic difference between the killer/assister and the victim. (1.0.0)